### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ R packages. If you already have a version of Bioconductor (>=3.3) installed,
 you can do gthe following:
 
 ```
-libary(BiocManager)
+library(BiocManager)
 BiocManager::install("genbankr")
 ```
 


### PR DESCRIPTION
Change `libary` to `library` so users can copy and run the code to install the package. Thanks for making this package for us users!